### PR TITLE
fix Chain issues: Incorrect order, Extra certs

### DIFF
--- a/renew_certificate.sh
+++ b/renew_certificate.sh
@@ -22,8 +22,8 @@ echo "Stopping stunnel and setting new stunnel certificates..."
 /etc/init.d/stunnel.sh stop
 
 cd letsencrypt/live/$DOMAIN
-cat privkey.pem cert.pem chain.pem > /etc/stunnel/stunnel.pem
-cp fullchain.pem /etc/stunnel/uca.pem
+cat privkey.pem cert.pem > /etc/stunnel/stunnel.pem
+cp chain.pem /etc/stunnel/uca.pem
 
 echo "Done! Service startup and cleanup will follow now..."
 /etc/init.d/stunnel.sh start


### PR DESCRIPTION
Using your script on my Qnap TS-469L running firmware version 4.2.1 will make the SSL test service found @
https://www.ssllabs.com/ssltest/analyze.html
report Chain issues: Incorrect order, Extra certs

My proposed change will fix this and change the relevant line in the report to:
Chain issues: None
